### PR TITLE
Add test for empty string in list to bracket.

### DIFF
--- a/test/Homework/Week04Spec.hs
+++ b/test/Homework/Week04Spec.hs
@@ -49,3 +49,5 @@ spec = do
       asList ["alpha", "beta", "gamma"] `shouldBe` "[alpha,beta,gamma]"
       asList [] `shouldBe` "[]"
       asList ["lonely"] `shouldBe` "[lonely]"
+      asList ["up", "", "down"] `shouldBe` "[up,down]"
+


### PR DESCRIPTION
`asList ["a", "", "b"]` probably should not return `"[a,,b]"`.

Also, though it was beyond my Haskell test-fu, the insertBST tests probably also need to at least test for insertion when elements compare as EQ.