### PR TITLE
Add missing deriving instance

### DIFF
--- a/src/Homework/Week07/Editor.hs
+++ b/src/Homework/Week07/Editor.hs
@@ -35,7 +35,7 @@ commands = map show [View, Edit, Next, Prev, Quit]
 -- Editor monad
 
 newtype Editor b a = Editor (StateT (b,Int) IO a)
-  deriving (Functor, Monad, MonadIO, MonadState (b,Int))
+  deriving (Functor, Applicative, Monad, MonadIO, MonadState (b,Int))
 
 runEditor :: Buffer b => Editor b a -> b -> IO a
 runEditor (Editor e) b = evalStateT e (b,0)


### PR DESCRIPTION
# Goals

Fix the `Editor` to allow running editors as the Week 07 homework requires.

# Implementation

In trying to work on the Week 7 work, I attempted to run the existing editor as described by the homework:

```sh
runhaskell StringBufEditor.hs
```

However, this failed to work resulting in the following error messaging:

```sh
Editor.hs:38:22: error:
    • No instance for (Applicative (Editor b))
        arising from the 'deriving' clause of a data type declaration
      Possible fix:
        use a standalone 'deriving instance' declaration,
          so you can specify the instance context yourself
    • When deriving the instance for (Monad (Editor b))
```

Not sure about what to do, I for a solution. I came across a solutions repo where old files were two years old _EXCEPT_ the `Editor.hs`. It had been [updated 8 months ago](https://github.com/bschwb/cis194-solutions/commit/0cab8a2b54f3232d6b84d47e758a9d8f07c65c50) to solve this exact issue! I copied in the fix (ie add `Applicative` to the list of instances in `Editor`'s `deriving` clause).