### PR TITLE
add test for a one-character ident

### DIFF
--- a/test/Homework/Week09Spec.hs
+++ b/test/Homework/Week09Spec.hs
@@ -42,6 +42,7 @@ spec = do
       pending
       runParser ident "foobar baz" `shouldBe` Just ("foobar", " baz")
       runParser ident "foo33fA" `shouldBe` Just ("foo33fA", "")
+      runParser ident "f" `shouldBe` Just ("f", "")
       runParser ident "2bad" `shouldBe` Nothing
       runParser ident "" `shouldBe` Nothing
 


### PR DESCRIPTION
The Week09 homework says `ident` should parse identifiers, which are "an alphabetic character followed by zero or more alphanumeric characters".

At first, I accidentally parsed an alpha character followed by **one** or more characters, but had passing tests. This test catches that.