### PR TITLE
Week11 tests

### DIFF
--- a/cis194.cabal
+++ b/cis194.cabal
@@ -57,13 +57,14 @@ test-suite cis194-test
   main-is:             Spec.hs
   build-depends:       base
                      , cis194
-                     , hspec
-                     , unordered-containers
-                     , time
+                     , MonadRandom
                      , QuickCheck
                      , aeson
                      , bytestring
+                     , hspec
                      , text
+                     , time
+                     , unordered-containers
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/src/Homework/Week11/Assignment.hs
+++ b/src/Homework/Week11/Assignment.hs
@@ -26,6 +26,7 @@ die = getRandom
 type Army = Int
 
 data Battlefield = Battlefield { attackers :: Army, defenders :: Army }
+  deriving (Show)
 
 -- #2 (there is no assignment #1, really)
 battle :: Battlefield -> Rand StdGen Battlefield

--- a/test/Homework/Week11Spec.hs
+++ b/test/Homework/Week11Spec.hs
@@ -4,10 +4,43 @@ module Homework.Week11Spec (
 ) where
 
 import Test.Hspec
+import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck
 
 import Control.Monad.Random
 import Homework.Week11.Assignment
+
+instance Arbitrary Battlefield where
+  arbitrary = sized $ \size -> do
+    attackerArmy <- choose (2, max size 2)
+    defenderArmy <- choose (1, max size 1)
+    return (Battlefield attackerArmy defenderArmy)
+
+prop_subtractsTwoFromBattle :: Battlefield -> IO ()
+prop_subtractsTwoFromBattle field = do
+  newField <- evalRandIO (battle (field :: Battlefield))
+  let totalUnitsLeft = attackers newField + defenders newField
+  checkTotalUnitsLeft totalUnitsLeft
+  where attackerArmy = attackers field
+        defenderArmy = defenders field
+        checkTotalUnitsLeft unitsLeft
+          -- For large armies, two units will always die.
+          | attackerArmy >= 3 && defenderArmy >= 2 =
+            unitsLeft `shouldBe` attackerArmy + defenderArmy - 2
+          -- For the minimum armies, one unit will always die.
+          | attackerArmy == 2 && defenderArmy == 1 =
+            unitsLeft `shouldBe` 2
+          -- For battles like Battlefield 3 1, one OR two armies could die.
+          | otherwise = return ()
+
+prop_findsWinner :: Battlefield -> IO ()
+prop_findsWinner field = do
+  newField <- evalRandIO (invade field)
+  newField `shouldSatisfy` \field ->
+    case field of
+      Battlefield _ 0 -> True
+      Battlefield 1 _ -> True
+      _ -> False
 
 main :: IO ()
 main = hspec spec
@@ -15,25 +48,10 @@ main = hspec spec
 spec :: Spec
 spec = do
   describe "battle" $ do
-    it "subtracts two units from the battle" $ do
-      pending
-      newField <- evalRandIO (battle (Battlefield 3 2))
-      attackers newField + defenders newField `shouldBe` 3
+    -- prop "subtracts two units from the battle" prop_subtractsTwoFromBattle
 
-    it "subtracts one unit from a small battle" $ do
-      pending
-      newField <- evalRandIO (battle (Battlefield 2 1))
-      attackers newField + defenders newField `shouldBe` 2
-
-  describe "invade" $ 
-    it "produces a winner" $ do
-      pending
-      newField <- evalRandIO (invade (Battlefield 10 10))
-      newField `shouldSatisfy` \field ->
-        case field of 
-          Battlefield _ 0 -> True
-          Battlefield 1 _ -> True
-          _ -> False
+  describe "invade" $ do
+    -- prop "produces a winner" prop_findsWinner
 
   describe "successProb" $ do
     it "finds a low probability of success" $ do

--- a/test/Homework/Week11Spec.hs
+++ b/test/Homework/Week11Spec.hs
@@ -49,9 +49,13 @@ spec :: Spec
 spec = do
   describe "battle" $ do
     -- prop "subtracts two units from the battle" prop_subtractsTwoFromBattle
+    it "is pending" $ do
+      pending
 
   describe "invade" $ do
     -- prop "produces a winner" prop_findsWinner
+    it "is pending too" $ do
+      pending
 
   describe "successProb" $ do
     it "finds a low probability of success" $ do

--- a/test/Homework/Week11Spec.hs
+++ b/test/Homework/Week11Spec.hs
@@ -1,0 +1,47 @@
+module Homework.Week11Spec (
+  main,
+  spec
+) where
+
+import Test.Hspec
+import Test.QuickCheck
+
+import Control.Monad.Random
+import Homework.Week11.Assignment
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "battle" $ do
+    it "subtracts two units from the battle" $ do
+      pending
+      newField <- evalRandIO (battle (Battlefield 3 2))
+      attackers newField + defenders newField `shouldBe` 3
+
+    it "subtracts one unit from a small battle" $ do
+      pending
+      newField <- evalRandIO (battle (Battlefield 2 1))
+      attackers newField + defenders newField `shouldBe` 2
+
+  describe "invade" $ 
+    it "produces a winner" $ do
+      pending
+      newField <- evalRandIO (invade (Battlefield 10 10))
+      newField `shouldSatisfy` \field ->
+        case field of 
+          Battlefield _ 0 -> True
+          Battlefield 1 _ -> True
+          _ -> False
+
+  describe "successProb" $ do
+    it "finds a low probability of success" $ do
+      pending
+      newField <- evalRandIO (successProb (Battlefield 2 20))
+      newField `shouldSatisfy` (0.1 >)
+
+    it "finds a high probability of success" $ do
+      pending
+      newField <- evalRandIO (successProb (Battlefield 20 2))
+      newField `shouldSatisfy` (0.9 <)


### PR DESCRIPTION
### Goals
Add some tests for Week11 (Risk)

### Implementation
- Since it's all random data, basically write some quickcheck tests for `battle` and `invade`.
- For `successProb`, just test that really one-sided setups correctly have low/high probabilities  

### For discussion
- This is working locally for me, but Travis is failing with
```
/home/travis/build/laser/cis-194-spring-2017/test/Homework/Week11Spec.hs:9:8:
    Could not find module ‘Control.Monad.Random’
    It is a member of the hidden package ‘MonadRandom-0.4.2.2@Monad_LbaXJr6Nhqd7LxAzlRvHiO’.
    Perhaps you need to add ‘MonadRandom’ to the build-depends in your .cabal file.
```
But `MonadRandom` is already in the build-depends of the [cabal file](https://github.com/laser/cis-194-spring-2017/blob/master/cis194.cabal#L43), so I don't know what the deal is.

- Is there a way to mark `prop` tests as `pending`? I couldn't figure it out, so I just commented them out